### PR TITLE
fixed ad logic

### DIFF
--- a/blocks.py
+++ b/blocks.py
@@ -327,16 +327,9 @@ DIGEST_HEADER = """
             <tbody><tr>
               <td align="center" valign="top" style="padding:0 50px;" class="em_aside">
                 <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center">
-		<!-- AD
-                  <tr>
-                    <td height="30" class="em_height"> </td>
-                 </tr>
-		<tr>
-                    <td align="center" valign="top">
-                      <a href="WEBLINK" target="_blank" style="text-decoration:none;"><img mc:edit="image6" class="em_full_img" src="IMAGELINK" width="1050" height="170" alt="IMAGEALT" border="0" style="display:block;font-family:Arial, sans-serif; font-size:20px; line-height:25px; color:#424242; max-width:520px; max-height:59.5px;"></a>
-                    </td>
-                  </tr>
-		-->
+"""
+
+DIGEST_LOGO = """
         <tbody>
             <tr>
                 <td height="30" class="em_height">&nbsp;</td>
@@ -354,15 +347,6 @@ DIGEST_HEADER = """
             <tr>
                 <td height="30" style="font-size:1px;line-height:1px;">&nbsp;</td>
             </tr>
-        <!-- AD
-        <tr>
-          <td style="mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;border-collapse: collapse; padding-bottom: 25px;">
-            <a href=WEBLINK style="text-decoration: none;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;border-collapse: collapse;" target="_blank">
-              <img alt="" border="0" class="em_full_img" height="180" src=IMAGELINK style="display: block;font-family: Arial, sans-serif;font-size: 20px;line-height: 25px;color: #424242;max-width: 520px;max-height: 59.5px;border: 0 !important;height: auto;outline: none !important;text-decoration: none;-ms-interpolation-mode: bicubic;" width="600">
-            </a>
-          </td>
-        </tr>
-        -->
 """
 
 # Footer HTML used in each digest

--- a/digest-template.txt
+++ b/digest-template.txt
@@ -1,3 +1,8 @@
+TOP AD
+Web link (or "none")
+Image source
+Alt text
+
 FEATURED
 
 NEWS
@@ -12,9 +17,19 @@ THE GRIND
 
 HUMOR
 
+DATA
+
+PODCASTS
+
+VIDEO
+
 EDITOR'S PICK
 
 AD
+Web link (or "none")
+Image source
+Alt text
+
 WEB LINK
 IMAGE LINK
 ALT TEXT


### PR DESCRIPTION
Files changed:
- blocks.py
- digest-template.txt
- make_digest.py

Fixes:
Allows for multiple ads with proper formatting. Ads appear in their own "section" with dividers. An ad above the Daily logo should be labeled as "TOP AD" and listed first.

Adds all functioning section headers to template.

Format for ads:
AD/TOP AD
Web link (where the ad goes to when you click it)
Source (WP post with image)
Alt text